### PR TITLE
댓글 작성 버그 수정

### DIFF
--- a/src/main/java/com/example/troubleshooter/service/CommentService.java
+++ b/src/main/java/com/example/troubleshooter/service/CommentService.java
@@ -21,7 +21,9 @@ public class CommentService {
     public void writeComment(Long postId, CommentRequestDto commentRequestDto, Long userId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."));
-        post.addComment(new Comment(commentRequestDto, userId));
+        Comment comment = new Comment(commentRequestDto, userId);
+        post.addComment(comment);
+        commentRepository.save(comment);
     }
 
     public void editComment(Long commentId, CommentRequestDto commentRequestDto, Long userId) {


### PR DESCRIPTION
CommentService에서 post와 comment의 관계만 맺어주고 DB엔 넣어주고 있지 않았습니다.
함수에 @Transactional 어노테이션을 다는 방법과 comment를 save해주는 방법 중 후자 방법으로 수정하였습니다.